### PR TITLE
Update X-Forwarded-For header instead of overriding it

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -23,6 +23,6 @@ server {
         proxy_pass http://localhost:3000;
         proxy_set_header Connection "upgrade";
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header X-Forwarded-for $remote_addr;
+        proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
     }
 }


### PR DESCRIPTION
- [x] I have read the [contributing](https://github.com/linuxserver/docker-snapdrop/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:
Switch from overriding the `X-Forwarded-For` header to updating it.

## Benefits of this PR and context:
When this container is behind a reverse proxy itself it overrides the incoming `X-Forwarded-For` header from the downstream reverse proxy. This is particularly problematic because Snadrop heavily relies on this information to create rooms.

## How Has This Been Tested?
I rebuilt the image on my server and deployed it on it behind a Caddy reverse proxy. It now works approprietly (2 devices that are not on the same network do not see each other).

## Source / References:
https://github.com/RobinLinus/snapdrop/blob/master/docs/local-dev.md#deployment-notes
I think it's tied to what is mentioned and might resolve #3 