### PR TITLE
Update readme-vars.yml

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -63,8 +63,6 @@ app_setup_block_enabled: true
 app_setup_block: |
   Webui is accessible at http://SERVERIP:PORT
 
-  If you intend to expose Snapdrop to the internet, edit /config/nginx/site-confs/default.conf and uncomment the real_ip settings
-
 # changelog
 changelogs:
   - { date: "20.01.23:", desc: "Rebase to alpine 3.17 with php8.1." }


### PR DESCRIPTION
Ref: https://github.com/linuxserver/docker-snapdrop/issues/14

The mentioned configs are no longer included by default. The topic of `real_ip` was briefly discussed internally somewhat recently and the general feeling was that we did not want to ship anything universal for nginx based images. Upstream (snapdrop) does not have specific documentation regarding the requirement for `real_ip` settings. The closest we will come for now is recommending the https://github.com/linuxserver/docker-mods/tree/swag-cloudflare-real-ip mod, which mentions the need to be applied to SWAG and images proxied by SWAG.